### PR TITLE
sstable: lazy load the index block in two level iterator

### DIFF
--- a/sstable/comparison_benchmark_test.go
+++ b/sstable/comparison_benchmark_test.go
@@ -1,0 +1,115 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sstable
+
+import (
+	"context"
+	"testing"
+)
+
+// simulateEagerLoading creates an iterator and immediately loads the index
+// to simulate what eager loading would have done
+func simulateEagerLoading(r *Reader, opts IterOptions) (*singleLevelIteratorRowBlocks, error) {
+	iter, err := newRowBlockSingleLevelIterator(context.Background(), r, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// Force index loading immediately (simulating eager loading)
+	if err := iter.ensureIndexLoaded(); err != nil {
+		iter.Close()
+		return nil, err
+	}
+
+	return iter, nil
+}
+
+// BenchmarkEagerVsLazyComparison compares eager vs lazy loading performance
+// How to: go test -bench=BenchmarkEagerVsLazyComparison -run=^$ ./sstable
+func BenchmarkEagerVsLazyComparison(b *testing.B) {
+	b.Run("LazyLoading_ConstructOnly", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			iter, err := newRowBlockSingleLevelIterator(context.Background(), globalReader, globalIterOpts)
+			if err != nil {
+				b.Fatal(err)
+			}
+			// Don't access index - pure construction cost
+			iter.Close()
+		}
+	})
+
+	b.Run("SimulatedEagerLoading_ConstructOnly", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			iter, err := simulateEagerLoading(globalReader, globalIterOpts)
+			if err != nil {
+				b.Fatal(err)
+			}
+			// Index was loaded during construction
+			iter.Close()
+		}
+	})
+
+	b.Run("LazyLoading_ConstructAndUse", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			iter, err := newRowBlockSingleLevelIterator(context.Background(), globalReader, globalIterOpts)
+			if err != nil {
+				b.Fatal(err)
+			}
+			// Use iterator (triggers lazy loading)
+			_ = iter.First()
+			iter.Close()
+		}
+	})
+
+	b.Run("SimulatedEagerLoading_ConstructAndUse", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			iter, err := simulateEagerLoading(globalReader, globalIterOpts)
+			if err != nil {
+				b.Fatal(err)
+			}
+			// Use iterator (index already loaded)
+			_ = iter.First()
+			iter.Close()
+		}
+	})
+}
+
+// BenchmarkShortLivedIterators simulates scenarios where iterators are created but not used
+// How to: go test -bench=BenchmarkShortLivedIterators -run=^$ ./sstable
+func BenchmarkShortLivedIterators(b *testing.B) {
+	b.Run("LazyLoading_ManyUnused", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			// Create 10 iterators but don't use them
+			for range 10 {
+				iter, err := newRowBlockSingleLevelIterator(context.Background(), globalReader, globalIterOpts)
+				if err != nil {
+					b.Fatal(err)
+				}
+				// Don't use - index never loaded
+				iter.Close()
+			}
+		}
+	})
+
+	b.Run("SimulatedEagerLoading_ManyUnused", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			// Create 10 iterators with eager loading simulation
+			for range 10 {
+				iter, err := simulateEagerLoading(globalReader, globalIterOpts)
+				if err != nil {
+					b.Fatal(err)
+				}
+				// Don't use but index was already loaded
+				iter.Close()
+			}
+		}
+	})
+}

--- a/sstable/data_test.go
+++ b/sstable/data_test.go
@@ -343,9 +343,10 @@ func runIterCmd(
 			si, _ := iter.(*singleLevelIteratorRowBlocks)
 			if twoLevelIter, ok := iter.(*twoLevelIteratorRowBlocks); ok {
 				si = &twoLevelIter.secondLevel
-				if twoLevelIter.topLevelIndex.Valid() {
-					fmt.Fprintf(&b, "|  topLevelIndex.Key() = %q\n", twoLevelIter.topLevelIndex.Separator())
-					bhp, err := twoLevelIter.topLevelIndex.BlockHandleWithProperties()
+				topLevelIndexIter := twoLevelIter.topLevelIndexIter()
+				if topLevelIndexIter.Valid() {
+					fmt.Fprintf(&b, "|  topLevelIndex.Key() = %q\n", topLevelIndexIter.Separator())
+					bhp, err := topLevelIndexIter.BlockHandleWithProperties()
 					if err != nil {
 						fmt.Fprintf(&b, "|  topLevelIndex entry failed to decode as BHP: %s\n", err)
 					} else {
@@ -355,7 +356,7 @@ func runIterCmd(
 				} else {
 					fmt.Fprintf(&b, "|  topLevelIndex iter invalid\n")
 				}
-				fmt.Fprintf(&b, "|  topLevelIndex.isDataInvalidated()=%t\n", twoLevelIter.topLevelIndex.IsDataInvalidated())
+				fmt.Fprintf(&b, "|  topLevelIndex.isDataInvalidated()=%t\n", topLevelIndexIter.IsDataInvalidated())
 			}
 			if si.index.Valid() {
 				fmt.Fprintf(&b, "|  index.Separator() = %q\n", si.index.Separator())

--- a/sstable/reader_iter_benchmark_test.go
+++ b/sstable/reader_iter_benchmark_test.go
@@ -1,0 +1,420 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sstable
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/pebble/bloom"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
+	"github.com/cockroachdb/pebble/sstable/block"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+// setupTestSSTable creates a test SSTable for benchmarking
+func setupTestSSTable(t testing.TB) (*Reader, func()) {
+	mem := vfs.NewMem()
+	f, err := mem.Create("test.sst", vfs.WriteCategoryUnspecified)
+	require.NoError(t, err)
+
+	w := NewWriter(objstorageprovider.NewFileWritable(f), WriterOptions{
+		BlockSize:      4096,
+		IndexBlockSize: 4096,
+		FilterPolicy:   bloom.FilterPolicy(10),
+		TableFormat:    TableFormatPebblev3,
+		Comparer:       base.DefaultComparer,
+		MergerName:     base.DefaultMerger.Name,
+	})
+
+	const numKeys = 10000
+	for i := range numKeys {
+		key := fmt.Appendf(nil, "key%08d", i)
+		value := fmt.Sprintf("value%d", i)
+		require.NoError(t, w.Set(key, []byte(value)))
+	}
+	require.NoError(t, w.Close())
+
+	// Open the file for reading
+	f2, err := mem.Open("test.sst")
+	require.NoError(t, err)
+
+	// Create reader
+	r, err := newReader(f2, ReaderOptions{
+		Comparer: base.DefaultComparer,
+		Merger:   base.DefaultMerger,
+	})
+	require.NoError(t, err)
+
+	cleanup := func() {
+		if r != nil {
+			r.Close()
+			// Reader.Close() should close the underlying file, so don't close f2 again
+		} else if f2 != nil {
+			f2.Close()
+		}
+	}
+
+	return r, cleanup
+}
+
+// BenchmarkIteratorConstruction measures the performance of iterator construction
+// with the current lazy loading implementation (default behavior)
+// How to: go test -bench=BenchmarkIteratorConstruction -count=5 -run=^$ ./sstable
+func BenchmarkIteratorConstruction(b *testing.B) {
+	r, cleanup := setupTestSSTable(b)
+	defer cleanup()
+
+	var stats base.InternalIteratorStats
+	var bufferPool block.BufferPool
+	bufferPool.Init(5)
+	defer bufferPool.Release()
+
+	iterOpts := IterOptions{
+		Transforms:           NoTransforms,
+		FilterBlockSizeLimit: NeverUseFilterBlock,
+		Env:                  ReadEnv{Block: block.ReadEnv{Stats: &stats, BufferPool: &bufferPool}},
+		ReaderProvider:       MakeTrivialReaderProvider(r),
+	}
+
+	b.Run("RowBlock", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			iter, err := newRowBlockSingleLevelIterator(context.Background(), r, iterOpts)
+			if err != nil {
+				b.Fatal(err)
+			}
+			iter.Close()
+		}
+	})
+}
+
+// BenchmarkIteratorConstructionWithFirstAccess measures construction + first access
+// to understand the total cost when index loading is actually needed
+// How to: go test -bench=BenchmarkIteratorConstructionWithFirstAccess -run=^$ ./sstable
+func BenchmarkIteratorConstructionWithFirstAccess(b *testing.B) {
+	r, cleanup := setupTestSSTable(b)
+	defer cleanup()
+
+	var stats base.InternalIteratorStats
+	var bufferPool block.BufferPool
+	bufferPool.Init(5)
+	defer bufferPool.Release()
+
+	iterOpts := IterOptions{
+		Transforms:           NoTransforms,
+		FilterBlockSizeLimit: NeverUseFilterBlock,
+		Env:                  ReadEnv{Block: block.ReadEnv{Stats: &stats, BufferPool: &bufferPool}},
+		ReaderProvider:       MakeTrivialReaderProvider(r),
+	}
+
+	b.Run("RowBlock_First", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			iter, err := newRowBlockSingleLevelIterator(context.Background(), r, iterOpts)
+			if err != nil {
+				b.Fatal(err)
+			}
+			_ = iter.First() // Trigger index loading
+			iter.Close()
+		}
+	})
+
+	b.Run("RowBlock_SeekGE", func(b *testing.B) {
+		key := []byte("key00005000") // Middle key
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			iter, err := newRowBlockSingleLevelIterator(context.Background(), r, iterOpts)
+			if err != nil {
+				b.Fatal(err)
+			}
+			_ = iter.SeekGE(key, base.SeekGEFlagsNone) // Trigger index loading
+			iter.Close()
+		}
+	})
+}
+
+// BenchmarkFirstAccessLatency compares the latency of first access operations
+// between lazy loading (index loaded on first access) vs when index is already loaded
+// How to: go test -bench=BenchmarkFirstAccessLatency -run=^$ ./sstable
+func BenchmarkFirstAccessLatency(b *testing.B) {
+	r, cleanup := setupTestSSTable(b)
+	defer cleanup()
+
+	var stats base.InternalIteratorStats
+	var bufferPool block.BufferPool
+	bufferPool.Init(5)
+	defer bufferPool.Release()
+
+	iterOpts := IterOptions{
+		Transforms:           NoTransforms,
+		FilterBlockSizeLimit: NeverUseFilterBlock,
+		Env:                  ReadEnv{Block: block.ReadEnv{Stats: &stats, BufferPool: &bufferPool}},
+		ReaderProvider:       MakeTrivialReaderProvider(r),
+	}
+
+	// Benchmark: First() call including index loading time (lazy loading)
+	b.Run("LazyLoading_First", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			iter, err := newRowBlockSingleLevelIterator(context.Background(), r, iterOpts)
+			if err != nil {
+				b.Fatal(err)
+			}
+			_ = iter.First() // Index loaded here
+			iter.Close()
+		}
+	})
+
+	// Benchmark: First() call when index is already loaded (simulated eager loading)
+	b.Run("EagerLoading_First", func(b *testing.B) {
+		// Create a single iterator and pre-load its index once
+		iter, err := newRowBlockSingleLevelIterator(context.Background(), r, iterOpts)
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer iter.Close()
+
+		_ = iter.First() // Pre-load index
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = iter.First() // Index already loaded - this is what we're measuring
+		}
+	})
+
+	// Benchmark: SeekGE() call including index loading time (lazy loading)
+	b.Run("LazyLoading_SeekGE", func(b *testing.B) {
+		key := []byte("key00005000") // Middle key
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			iter, err := newRowBlockSingleLevelIterator(context.Background(), r, iterOpts)
+			if err != nil {
+				b.Fatal(err)
+			}
+			_ = iter.SeekGE(key, base.SeekGEFlagsNone) // Index loaded here
+			iter.Close()
+		}
+	})
+
+	// Benchmark: SeekGE() call when index is already loaded (simulated eager loading)
+	b.Run("EagerLoading_SeekGE", func(b *testing.B) {
+		key := []byte("key00005000") // Middle key
+
+		// Create a single iterator and pre-load its index once
+		iter, err := newRowBlockSingleLevelIterator(context.Background(), r, iterOpts)
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer iter.Close()
+
+		_ = iter.First() // Pre-load index
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = iter.SeekGE(key, base.SeekGEFlagsNone) // Index already loaded - this is what we're measuring
+		}
+	})
+}
+
+// BenchmarkBloomFilterEarlyExit measures the performance benefit of lazy loading
+// when bloom filter rejects the prefix (index never loaded)
+// How to: go test -bench=BenchmarkBloomFilterEarlyExit -run=^$ ./sstable
+func BenchmarkBloomFilterEarlyExit(b *testing.B) {
+	r, cleanup := setupTestSSTable(b)
+	defer cleanup()
+
+	var stats base.InternalIteratorStats
+	var bufferPool block.BufferPool
+	bufferPool.Init(5)
+	defer bufferPool.Release()
+
+	iterOpts := IterOptions{
+		Transforms:           NoTransforms,
+		FilterBlockSizeLimit: AlwaysUseFilterBlock, // Enable bloom filter
+		Env:                  ReadEnv{Block: block.ReadEnv{Stats: &stats, BufferPool: &bufferPool}},
+		ReaderProvider:       MakeTrivialReaderProvider(r),
+	}
+
+	// Use prefixes that likely don't exist to trigger bloom filter rejection
+	rejectedPrefixes := [][]byte{
+		[]byte("notfound1"),
+		[]byte("notfound2"),
+		[]byte("notfound3"),
+		[]byte("zzzzzzzzz"),
+	}
+
+	b.Run("SeekPrefixGE_BloomReject", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			iter, err := newRowBlockSingleLevelIterator(context.Background(), r, iterOpts)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			prefix := rejectedPrefixes[i%len(rejectedPrefixes)]
+			_ = iter.SeekPrefixGE(prefix, prefix, base.SeekGEFlagsNone)
+			iter.Close()
+		}
+	})
+
+	// Compare with existing prefixes that will be found
+	existingPrefixes := [][]byte{
+		[]byte("key00001000"),
+		[]byte("key00005000"),
+		[]byte("key00009000"),
+	}
+
+	b.Run("SeekPrefixGE_BloomAccept", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			iter, err := newRowBlockSingleLevelIterator(context.Background(), r, iterOpts)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			prefix := existingPrefixes[i%len(existingPrefixes)]
+			_ = iter.SeekPrefixGE(prefix, prefix, base.SeekGEFlagsNone)
+			iter.Close()
+		}
+	})
+}
+
+// BenchmarkBatchIteratorCreation simulates creating many iterators
+// where only some are actually used (common in merge iterator scenarios)
+// How to: go test -bench=BenchmarkBatchIteratorCreation -run=^$ ./sstable
+func BenchmarkBatchIteratorCreation(b *testing.B) {
+	r, cleanup := setupTestSSTable(b)
+	defer cleanup()
+
+	var stats base.InternalIteratorStats
+	var bufferPool block.BufferPool
+	bufferPool.Init(5)
+	defer bufferPool.Release()
+
+	iterOpts := IterOptions{
+		Transforms:           NoTransforms,
+		FilterBlockSizeLimit: NeverUseFilterBlock,
+		Env:                  ReadEnv{Block: block.ReadEnv{Stats: &stats, BufferPool: &bufferPool}},
+		ReaderProvider:       MakeTrivialReaderProvider(r),
+	}
+
+	b.Run("CreateMany_UseNone", func(b *testing.B) {
+		const batchSize = 10
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			iters := make([]*singleLevelIteratorRowBlocks, batchSize)
+
+			// Create many iterators
+			for j := range batchSize {
+				iter, err := newRowBlockSingleLevelIterator(context.Background(), r, iterOpts)
+				if err != nil {
+					b.Fatal(err)
+				}
+				iters[j] = iter
+			}
+
+			// Close all without using them (index never loaded)
+			for j := range batchSize {
+				iters[j].Close()
+			}
+		}
+	})
+
+	b.Run("CreateMany_UseSome", func(b *testing.B) {
+		const batchSize = 10
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			iters := make([]*singleLevelIteratorRowBlocks, batchSize)
+
+			// Create many iterators
+			for j := range batchSize {
+				iter, err := newRowBlockSingleLevelIterator(context.Background(), r, iterOpts)
+				if err != nil {
+					b.Fatal(err)
+				}
+				iters[j] = iter
+			}
+
+			// Use only some of them (triggers index loading for those)
+			for j := range batchSize {
+				if j%3 == 0 { // Use every 3rd iterator
+					_ = iters[j].First()
+				}
+			}
+
+			// Close all
+			for j := range batchSize {
+				iters[j].Close()
+			}
+		}
+	})
+}
+
+// TestLazyLoadingBehavior verifies that lazy loading works as expected
+// How to: go test -run TestLazyLoadingBehavior -v ./sstable
+func TestLazyLoadingBehavior(t *testing.T) {
+	r, cleanup := setupTestSSTable(t)
+	defer cleanup()
+
+	var stats base.InternalIteratorStats
+	var bufferPool block.BufferPool
+	bufferPool.Init(5)
+	defer bufferPool.Release()
+
+	iterOpts := IterOptions{
+		Transforms:           NoTransforms,
+		FilterBlockSizeLimit: NeverUseFilterBlock,
+		Env:                  ReadEnv{Block: block.ReadEnv{Stats: &stats, BufferPool: &bufferPool}},
+		ReaderProvider:       MakeTrivialReaderProvider(r),
+	}
+
+	t.Run("IndexNotLoadedOnConstruction", func(t *testing.T) {
+		iter, err := newRowBlockSingleLevelIterator(context.Background(), r, iterOpts)
+		require.NoError(t, err)
+		defer iter.Close()
+
+		// Index should not be loaded yet
+		require.False(t, iter.indexLoaded, "Index should not be loaded on construction")
+	})
+
+	t.Run("IndexLoadedOnFirstAccess", func(t *testing.T) {
+		iter, err := newRowBlockSingleLevelIterator(context.Background(), r, iterOpts)
+		require.NoError(t, err)
+		defer iter.Close()
+
+		// Index should not be loaded yet
+		require.False(t, iter.indexLoaded, "Index should not be loaded on construction")
+
+		// Trigger index loading
+		_ = iter.First()
+
+		// Index should now be loaded
+		require.True(t, iter.indexLoaded, "Index should be loaded after first access")
+	})
+
+	t.Run("IndexStaysLoadedAfterPoolReuse", func(t *testing.T) {
+		iter, err := newRowBlockSingleLevelIterator(context.Background(), r, iterOpts)
+		require.NoError(t, err)
+
+		// Load the index
+		_ = iter.First()
+		require.True(t, iter.indexLoaded, "Index should be loaded after first access")
+
+		// Close and return to pool
+		iter.Close()
+
+		// Create new iterator (may reuse from pool)
+		iter2, err := newRowBlockSingleLevelIterator(context.Background(), r, iterOpts)
+		require.NoError(t, err)
+		defer iter2.Close()
+
+		// Index should not be loaded for new iterator (flag reset on pool reuse)
+		require.False(t, iter2.indexLoaded, "Index should not be loaded on new iterator from pool")
+	})
+}

--- a/sstable/reader_iter_single_lvl.go
+++ b/sstable/reader_iter_single_lvl.go
@@ -170,6 +170,9 @@ type singleLevelIterator[I any, PI indexBlockIterator[I], D any, PD dataBlockIte
 	// All fields above this field are cleared when resetting the iterator for reuse.
 	clearForResetBoundary struct{}
 
+	// Lazy loading flag - must be below clearForResetBoundary to survive pool reuse
+	indexLoaded bool
+
 	index I
 	data  D
 	// inPool is set to true before putting the iterator in the reusable pool;
@@ -214,14 +217,9 @@ func newColumnBlockSingleLevelIterator(
 		i.vbRH = r.blockReader.UsePreallocatedReadHandle(objstorage.NoReadBefore, &i.vbRHPrealloc)
 	}
 	i.data.InitOnce(r.keySchema, r.Comparer, &i.internalValueConstructor)
-	indexH, err := r.readTopLevelIndexBlock(ctx, i.readEnv.Block, i.indexFilterRH)
-	if err == nil {
-		err = i.index.InitHandle(r.Comparer, indexH, opts.Transforms)
-	}
-	if err != nil {
-		_ = i.Close()
-		return nil, err
-	}
+
+	// Use lazy loading by default - index will be loaded on first access
+	i.indexLoaded = false
 	return i, nil
 }
 
@@ -254,14 +252,8 @@ func newRowBlockSingleLevelIterator(
 		i.data.SetHasValuePrefix(true)
 	}
 
-	indexH, err := r.readTopLevelIndexBlock(ctx, i.readEnv.Block, i.indexFilterRH)
-	if err == nil {
-		err = i.index.InitHandle(r.Comparer, indexH, opts.Transforms)
-	}
-	if err != nil {
-		_ = i.Close()
-		return nil, err
-	}
+	// Use lazy loading by default - index will be loaded on first access
+	i.indexLoaded = false
 	return i, nil
 }
 
@@ -340,7 +332,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) initBounds() {
 	}
 	i.blockUpper = i.upper
 	// TODO(radu): this should be >= 0 if blockUpper is inclusive.
-	if i.blockUpper != nil && PI(&i.index).SeparatorLT(i.blockUpper) {
+	if i.blockUpper != nil && i.indexIter().SeparatorLT(i.blockUpper) {
 		// The upper-bound is greater than the index key which itself is greater
 		// than or equal to every key in the block. No need to check the
 		// upper-bound again for this block. Even if blockUpper is inclusive
@@ -361,7 +353,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) initBoundsForAlreadyLoadedBlock() {
 	}
 	i.blockUpper = i.upper
 	// TODO(radu): this should be >= 0 if blockUpper is inclusive.
-	if i.blockUpper != nil && PI(&i.index).SeparatorLT(i.blockUpper) {
+	if i.blockUpper != nil && i.indexIter().SeparatorLT(i.blockUpper) {
 		// The upper-bound is greater than the index key which itself is greater
 		// than or equal to every key in the block. No need to check the
 		// upper-bound again for this block.
@@ -449,14 +441,14 @@ func (i *singleLevelIterator[I, PI, P, PD]) SetContext(ctx context.Context) {
 // unpositioned. If unsuccessful, it sets i.err to any error encountered, which
 // may be nil if we have simply exhausted the entire table.
 func (i *singleLevelIterator[I, PI, P, PD]) loadDataBlock(dir int8) loadBlockResult {
-	if !PI(&i.index).Valid() {
+	if !i.indexIter().Valid() {
 		// Ensure the data block iterator is invalidated even if loading of the block
 		// fails.
 		PD(&i.data).Invalidate()
 		return loadBlockFailed
 	}
 	// Load the next block.
-	bhp, err := PI(&i.index).BlockHandleWithProperties()
+	bhp, err := i.indexIter().BlockHandleWithProperties()
 	if i.dataBH == bhp.Handle && PD(&i.data).Valid() {
 		// We're already at the data block we want to load. Reset bounds in case
 		// they changed since the last seek, but don't reload the block from cache
@@ -542,7 +534,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) resolveMaybeExcluded(dir int8) inter
 	// need.
 	if dir > 0 {
 		// Forward iteration.
-		if i.bpfs.boundLimitedFilter.KeyIsWithinUpperBound(PI(&i.index).Separator()) {
+		if i.bpfs.boundLimitedFilter.KeyIsWithinUpperBound(i.indexIter().Separator()) {
 			return blockExcluded
 		}
 		return blockIntersects
@@ -566,19 +558,19 @@ func (i *singleLevelIterator[I, PI, D, PD]) resolveMaybeExcluded(dir int8) inter
 	// previous block's separator, which provides an inclusive lower bound on
 	// the original block's keys. Afterwards, we step forward to restore our
 	// index position.
-	if !PI(&i.index).Prev() {
+	if !i.indexIter().Prev() {
 		// The original block points to the first block of this index block. If
 		// there's a two-level index, it could potentially provide a lower
 		// bound, but the code refactoring necessary to read it doesn't seem
 		// worth the payoff. We fall through to loading the block.
-	} else if i.bpfs.boundLimitedFilter.KeyIsWithinLowerBound(PI(&i.index).Separator()) {
+	} else if i.bpfs.boundLimitedFilter.KeyIsWithinLowerBound(i.indexIter().Separator()) {
 		// The lower-bound on the original block falls within the filter's
 		// bounds, and we can skip the block (after restoring our current index
 		// position).
-		_ = PI(&i.index).Next()
+		_ = i.indexIter().Next()
 		return blockExcluded
 	}
-	_ = PI(&i.index).Next()
+	_ = i.indexIter().Next()
 	return blockIntersects
 }
 
@@ -688,8 +680,8 @@ func (i *singleLevelIterator[I, PI, D, PD]) seekGEHelper(
 	// by trySeekUsingNext, or by monotonically increasing bounds (i.boundsCmp).
 
 	var dontSeekWithinBlock bool
-	if !PD(&i.data).IsDataInvalidated() && PD(&i.data).Valid() && PI(&i.index).Valid() &&
-		boundsCmp > 0 && PI(&i.index).SeparatorGT(key, true /* orEqual */) {
+	if !PD(&i.data).IsDataInvalidated() && PD(&i.data).Valid() && i.indexIter().Valid() &&
+		boundsCmp > 0 && i.indexIter().SeparatorGT(key, true /* orEqual */) {
 		// Fast-path: The bounds have moved forward and this SeekGE is
 		// respecting the lower bound (guaranteed by Iterator). We know that the
 		// iterator must already be positioned within or just outside the
@@ -742,7 +734,11 @@ func (i *singleLevelIterator[I, PI, D, PD]) seekGEHelper(
 
 		// Slow-path.
 
-		if !PI(&i.index).SeekGE(key) {
+		indexIter := i.indexIter()
+		if i.err != nil {
+			return nil
+		}
+		if !indexIter.SeekGE(key) {
 			// The target key is greater than any key in the index block.
 			// Invalidate the block iterator so that a subsequent call to Prev()
 			// will return the last key in the table.
@@ -761,7 +757,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) seekGEHelper(
 			// multiple blocks. If upper is exclusive we pass orEqual=true
 			// below, else we require the separator to be strictly greater than
 			// upper.
-			if i.upper != nil && PI(&i.index).SeparatorGT(i.upper, !i.endKeyInclusive) {
+			if i.upper != nil && indexIter.SeparatorGT(i.upper, !i.endKeyInclusive) {
 				i.exhaustedBounds = +1
 				return nil
 			}
@@ -818,6 +814,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) seekPrefixGE(
 			flags = flags.DisableTrySeekUsingNext()
 		}
 		i.lastBloomFilterMatched = false
+
 		// Check prefix bloom filter.
 		var mayContain bool
 		mayContain, i.err = i.bloomFilterMayContain(prefix)
@@ -922,7 +919,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) virtualLastSeekLE() *base.InternalKV
 	i.boundsCmp = 0
 	i.positionedUsingLatestBounds = true
 
-	indexOk := PI(&i.index).SeekGE(key)
+	indexOk := i.indexIter().SeekGE(key)
 	// We can have multiple internal keys with the same user key as the seek
 	// key. In that case, we want the last (greatest) internal key.
 	//
@@ -942,8 +939,8 @@ func (i *singleLevelIterator[I, PI, D, PD]) virtualLastSeekLE() *base.InternalKV
 	// for now.
 	// TODO(jackson): Consider implementing SeekLE since it's easier to do in
 	// colblk.
-	for indexOk && bytes.Equal(PI(&i.index).Separator(), key) {
-		indexOk = PI(&i.index).Next()
+	for indexOk && bytes.Equal(i.indexIter().Separator(), key) {
+		indexOk = i.indexIter().Next()
 	}
 	if !indexOk {
 		// Cases A or B1 where B1 exhausted all blocks. In both cases the last block
@@ -1020,7 +1017,11 @@ func (i *singleLevelIterator[I, PI, D, PD]) SeekLT(
 	i.positionedUsingLatestBounds = true
 
 	var dontSeekWithinBlock bool
-	if !PD(&i.data).IsDataInvalidated() && PD(&i.data).Valid() && PI(&i.index).Valid() &&
+	indexIter := i.indexIter()
+	if i.err != nil {
+		return nil
+	}
+	if !PD(&i.data).IsDataInvalidated() && PD(&i.data).Valid() && indexIter.Valid() &&
 		boundsCmp < 0 && !PD(&i.data).IsLowerBound(key) {
 		// Fast-path: The bounds have moved backward, and this SeekLT is
 		// respecting the upper bound (guaranteed by Iterator). We know that
@@ -1047,8 +1048,12 @@ func (i *singleLevelIterator[I, PI, D, PD]) SeekLT(
 		// externally ensured that the filter is disabled (through returning
 		// Intersects=false irrespective of the block props provided) during
 		// seeks.
-		if !PI(&i.index).SeekGE(key) {
-			if !PI(&i.index).Last() {
+		indexIter := i.indexIter()
+		if i.err != nil {
+			return nil
+		}
+		if !indexIter.SeekGE(key) {
+			if !indexIter.Last() {
 				return nil
 			}
 		}
@@ -1063,7 +1068,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) SeekLT(
 			// that the previous block starts with keys <= ikey.UserKey since
 			// even though this is the current block's separator, the same
 			// user key can span multiple blocks.
-			if i.lower != nil && PI(&i.index).SeparatorLT(i.lower) {
+			if i.lower != nil && indexIter.SeparatorLT(i.lower) {
 				i.exhaustedBounds = -1
 				return nil
 			}
@@ -1121,7 +1126,11 @@ func (i *singleLevelIterator[I, PI, D, PD]) firstInternal() *base.InternalKV {
 	// Seek optimization only applies until iterator is first positioned after SetBounds.
 	i.boundsCmp = 0
 
-	if !PI(&i.index).First() {
+	indexIter := i.indexIter()
+	if i.err != nil {
+		return nil
+	}
+	if !indexIter.First() {
 		PD(&i.data).Invalidate()
 		return nil
 	}
@@ -1149,7 +1158,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) firstInternal() *base.InternalKV {
 		// same user key can span multiple blocks. If upper is exclusive we pass
 		// orEqual=true below, else we require the separator to be strictly
 		// greater than upper.
-		if i.upper != nil && PI(&i.index).SeparatorGT(i.upper, !i.endKeyInclusive) {
+		if i.upper != nil && i.indexIter().SeparatorGT(i.upper, !i.endKeyInclusive) {
 			i.exhaustedBounds = +1
 			return nil
 		}
@@ -1185,7 +1194,11 @@ func (i *singleLevelIterator[I, PI, D, PD]) lastInternal() *base.InternalKV {
 	// Seek optimization only applies until iterator is first positioned after SetBounds.
 	i.boundsCmp = 0
 
-	if !PI(&i.index).Last() {
+	indexIter := i.indexIter()
+	if i.err != nil {
+		return nil
+	}
+	if !indexIter.Last() {
 		PD(&i.data).Invalidate()
 		return nil
 	}
@@ -1208,7 +1221,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) lastInternal() *base.InternalKV {
 		// already exceeded. Note that the previous block starts with keys <=
 		// key.UserKey since even though this is the current block's
 		// separator, the same user key can span multiple blocks.
-		if i.lower != nil && PI(&i.index).SeparatorLT(i.lower) {
+		if i.lower != nil && indexIter.SeparatorLT(i.lower) {
 			i.exhaustedBounds = -1
 			return nil
 		}
@@ -1273,16 +1286,16 @@ func (i *singleLevelIterator[I, PI, D, PD]) NextPrefix(succKey []byte) *base.Int
 	// Did not find prefix in the existing data block. This is the slow-path
 	// where we effectively seek the iterator.
 	// The key is likely to be in the next data block, so try one step.
-	if !PI(&i.index).Next() {
+	if !i.indexIter().Next() {
 		// The target key is greater than any key in the index block.
 		// Invalidate the block iterator so that a subsequent call to Prev()
 		// will return the last key in the table.
 		PD(&i.data).Invalidate()
 		return nil
 	}
-	if PI(&i.index).SeparatorLT(succKey) {
+	if i.indexIter().SeparatorLT(succKey) {
 		// Not in the next data block, so seek the index.
-		if !PI(&i.index).SeekGE(succKey) {
+		if !i.indexIter().SeekGE(succKey) {
 			// The target key is greater than any key in the index block.
 			// Invalidate the block iterator so that a subsequent call to Prev()
 			// will return the last key in the table.
@@ -1301,7 +1314,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) NextPrefix(succKey []byte) *base.Int
 		// is the block separator, the same user key can span multiple blocks.
 		// If upper is exclusive we pass orEqual=true below, else we require
 		// the separator to be strictly greater than upper.
-		if i.upper != nil && PI(&i.index).SeparatorGT(i.upper, !i.endKeyInclusive) {
+		if i.upper != nil && i.indexIter().SeparatorGT(i.upper, !i.endKeyInclusive) {
 			i.exhaustedBounds = +1
 			return nil
 		}
@@ -1344,7 +1357,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) Prev() *base.InternalKV {
 
 func (i *singleLevelIterator[I, PI, D, PD]) skipForward() *base.InternalKV {
 	for {
-		if !PI(&i.index).Next() {
+		if !i.indexIter().Next() {
 			PD(&i.data).Invalidate()
 			break
 		}
@@ -1366,7 +1379,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) skipForward() *base.InternalKV {
 			// the same user key can span multiple blocks. If upper is exclusive
 			// we pass orEqual=true below, else we require the separator to be
 			// strictly greater than upper.
-			if i.upper != nil && PI(&i.index).SeparatorGT(i.upper, !i.endKeyInclusive) {
+			if i.upper != nil && i.indexIter().SeparatorGT(i.upper, !i.endKeyInclusive) {
 				i.exhaustedBounds = +1
 				return nil
 			}
@@ -1422,7 +1435,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) skipForward() *base.InternalKV {
 
 func (i *singleLevelIterator[I, PI, D, PD]) skipBackward() *base.InternalKV {
 	for {
-		if !PI(&i.index).Prev() {
+		if !i.indexIter().Prev() {
 			PD(&i.data).Invalidate()
 			break
 		}
@@ -1442,7 +1455,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) skipBackward() *base.InternalKV {
 			// bound is already exceeded. Note that the previous block starts with
 			// keys <= key.UserKey since even though this is the current block's
 			// separator, the same user key can span multiple blocks.
-			if i.lower != nil && PI(&i.index).SeparatorLT(i.lower) {
+			if i.lower != nil && i.indexIter().SeparatorLT(i.lower) {
 				i.exhaustedBounds = -1
 				return nil
 			}
@@ -1454,7 +1467,7 @@ func (i *singleLevelIterator[I, PI, D, PD]) skipBackward() *base.InternalKV {
 			// safe to assume that there are no keys if we keep skipping backwards.
 			// Check the previous block, but check the lower bound before doing
 			// that.
-			if i.lower != nil && PI(&i.index).SeparatorLT(i.lower) {
+			if i.lower != nil && i.indexIter().SeparatorLT(i.lower) {
 				i.exhaustedBounds = -1
 				return nil
 			}
@@ -1514,6 +1527,8 @@ func (i *singleLevelIterator[I, PI, D, PD]) closeInternal() error {
 	}
 	var err error
 	err = firstError(err, PD(&i.data).Close())
+	// Always close index iterator unconditionally to avoid BufferPool panic
+	// Even if lazy loading wasn't used, the index might have been initialized
 	err = firstError(err, PI(&i.index).Close())
 	if i.indexFilterRH != nil {
 		err = firstError(err, i.indexFilterRH.Close())
@@ -1532,6 +1547,8 @@ func (i *singleLevelIterator[I, PI, D, PD]) closeInternal() error {
 		err = firstError(err, i.vbRH.Close())
 		i.vbRH = nil
 	}
+	// Reset indexLoaded flag for pool reuse
+	i.indexLoaded = false
 	return err
 }
 
@@ -1545,4 +1562,28 @@ func (i *singleLevelIterator[I, PI, D, PD]) String() string {
 // DebugTree is part of the InternalIterator interface.
 func (i *singleLevelIterator[I, PI, D, PD]) DebugTree(tp treeprinter.Node) {
 	tp.Childf("%T(%p) fileNum=%s", i, i, i.String())
+}
+
+func (i *singleLevelIterator[I, PI, D, PD]) ensureIndexLoaded() error {
+	if i.indexLoaded {
+		return nil
+	}
+
+	indexH, err := i.reader.readTopLevelIndexBlock(i.ctx, i.readEnv.Block, i.indexFilterRH)
+	if err == nil {
+		err = PI(&i.index).InitHandle(i.reader.Comparer, indexH, i.transforms)
+	}
+	if err != nil {
+		return err
+	}
+
+	i.indexLoaded = true
+	return nil
+}
+
+func (i *singleLevelIterator[I, PI, D, PD]) indexIter() PI {
+	if err := i.ensureIndexLoaded(); err != nil {
+		i.err = err
+	}
+	return PI(&i.index)
 }

--- a/sstable/reader_iter_test.go
+++ b/sstable/reader_iter_test.go
@@ -68,13 +68,18 @@ func TestIteratorErrorOnInit(t *testing.T) {
 			require.Error(t, iter.Error())
 			iter.Close()
 		} else {
-			_, err := newRowBlockTwoLevelIterator(context.Background(), r, IterOptions{
+			iter, err := newRowBlockTwoLevelIterator(context.Background(), r, IterOptions{
 				Transforms:           NoTransforms,
 				FilterBlockSizeLimit: NeverUseFilterBlock,
 				Env:                  ReadEnv{Block: block.ReadEnv{Stats: &stats, BufferPool: &pool}},
 				ReaderProvider:       MakeTrivialReaderProvider(r),
 			})
-			require.Error(t, err)
+			// Two-level iterators use lazy loading - creation succeeds but first access fails
+			require.NoError(t, err)
+			// Error should surface when trying to use the iterator
+			_ = iter.First()
+			require.Error(t, iter.Error())
+			iter.Close()
 		}
 	}
 }

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -78,6 +78,7 @@ func (i *twoLevelIterator[I, PI, D, PD]) loadSecondLevelIndexBlock(dir int8) loa
 		i.secondLevel.err = err
 		return loadBlockFailed
 	}
+	i.secondLevel.indexLoaded = true
 	return loadBlockOK
 }
 

--- a/sstable/reader_iter_two_lvl.go
+++ b/sstable/reader_iter_two_lvl.go
@@ -32,6 +32,9 @@ type twoLevelIterator[I any, PI indexBlockIterator[I], D any, PD dataBlockIterat
 	// false - any filtering happens at the top level.
 	useFilterBlock         bool
 	lastBloomFilterMatched bool
+
+	// Lazy loading flag for top-level index
+	topLevelIndexLoaded bool
 }
 
 var _ Iterator = (*twoLevelIteratorRowBlocks)(nil)
@@ -45,10 +48,17 @@ func (i *twoLevelIterator[I, PI, D, PD]) loadSecondLevelIndexBlock(dir int8) loa
 	// the index fails.
 	PD(&i.secondLevel.data).Invalidate()
 	PI(&i.secondLevel.index).Invalidate()
-	if !PI(&i.topLevelIndex).Valid() {
+	topLevelIndexIter := i.topLevelIndexIter()
+	if i.secondLevel.err != nil {
 		return loadBlockFailed
 	}
-	bhp, err := PI(&i.topLevelIndex).BlockHandleWithProperties()
+	if !topLevelIndexIter.Valid() {
+		if i.secondLevel.err != nil {
+			return loadBlockFailed
+		}
+		return loadBlockFailed
+	}
+	bhp, err := topLevelIndexIter.BlockHandleWithProperties()
 	if err != nil {
 		i.secondLevel.err = base.CorruptionErrorf("pebble/table: corrupt top level index entry (%v)", err)
 		return loadBlockFailed
@@ -105,7 +115,14 @@ func (i *twoLevelIterator[I, PI, D, PD]) resolveMaybeExcluded(dir int8) intersec
 	// need.
 	if dir > 0 {
 		// Forward iteration.
-		if i.secondLevel.bpfs.boundLimitedFilter.KeyIsWithinUpperBound(PI(&i.topLevelIndex).Separator()) {
+		topLevelIndexIter := i.topLevelIndexIter()
+		if i.secondLevel.err != nil {
+			return blockIntersects // Conservative fallback on error
+		}
+		if i.secondLevel.bpfs.boundLimitedFilter.KeyIsWithinUpperBound(topLevelIndexIter.Separator()) {
+			if i.secondLevel.err != nil {
+				return blockIntersects // Conservative fallback on error
+			}
 			return blockExcluded
 		}
 		return blockIntersects
@@ -129,19 +146,48 @@ func (i *twoLevelIterator[I, PI, D, PD]) resolveMaybeExcluded(dir int8) intersec
 	// the previous block's separator, which provides an inclusive lower bound
 	// on the original index block's keys. Afterwards, we step forward to
 	// restore our top-level index position.
-	if !PI(&i.topLevelIndex).Prev() {
+	topLevelIndexIter := i.topLevelIndexIter()
+	if i.secondLevel.err != nil {
+		return blockIntersects // Conservative fallback on error
+	}
+	if !topLevelIndexIter.Prev() {
+		if i.secondLevel.err != nil {
+			return blockIntersects // Conservative fallback on error
+		}
 		// The original block points to the first index block of this table. If
 		// we knew the lower bound for the entire table, it could provide a
 		// lower bound, but the code refactoring necessary to read it doesn't
 		// seem worth the payoff. We fall through to loading the block.
-	} else if i.secondLevel.bpfs.boundLimitedFilter.KeyIsWithinLowerBound(PI(&i.topLevelIndex).Separator()) {
-		// The lower-bound on the original index block falls within the filter's
-		// bounds, and we can skip the block (after restoring our current
-		// top-level index position).
-		_ = PI(&i.topLevelIndex).Next()
-		return blockExcluded
+	} else {
+		if i.secondLevel.err != nil {
+			return blockIntersects // Conservative fallback on error
+		}
+		if i.secondLevel.bpfs.boundLimitedFilter.KeyIsWithinLowerBound(topLevelIndexIter.Separator()) {
+			if i.secondLevel.err != nil {
+				return blockIntersects // Conservative fallback on error
+			}
+			// The lower-bound on the original index block falls within the filter's
+			// bounds, and we can skip the block (after restoring our current
+			// top-level index position).
+			topLevelIndexIter = i.topLevelIndexIter()
+			if i.secondLevel.err != nil {
+				return blockIntersects // Conservative fallback on error
+			}
+			_ = topLevelIndexIter.Next()
+			if i.secondLevel.err != nil {
+				return blockIntersects // Conservative fallback on error
+			}
+			return blockExcluded
+		}
 	}
-	_ = PI(&i.topLevelIndex).Next()
+	topLevelIndexIter = i.topLevelIndexIter()
+	if i.secondLevel.err != nil {
+		return blockIntersects // Conservative fallback on error
+	}
+	_ = topLevelIndexIter.Next()
+	if i.secondLevel.err != nil {
+		return blockIntersects // Conservative fallback on error
+	}
 	return blockIntersects
 }
 
@@ -182,14 +228,9 @@ func newColumnBlockTwoLevelIterator(
 			objstorage.NoReadBefore, &i.secondLevel.vbRHPrealloc)
 	}
 	i.secondLevel.data.InitOnce(r.keySchema, r.Comparer, &i.secondLevel.internalValueConstructor)
-	topLevelIndexH, err := r.readTopLevelIndexBlock(ctx, i.secondLevel.readEnv.Block, i.secondLevel.indexFilterRH)
-	if err == nil {
-		err = i.topLevelIndex.InitHandle(r.Comparer, topLevelIndexH, opts.Transforms)
-	}
-	if err != nil {
-		_ = i.Close()
-		return nil, err
-	}
+
+	// Use lazy loading by default - top-level index will be loaded on first access
+	i.topLevelIndexLoaded = false
 	return i, nil
 }
 
@@ -236,14 +277,8 @@ func newRowBlockTwoLevelIterator(
 		i.secondLevel.data.SetHasValuePrefix(true)
 	}
 
-	topLevelIndexH, err := r.readTopLevelIndexBlock(ctx, i.secondLevel.readEnv.Block, i.secondLevel.indexFilterRH)
-	if err == nil {
-		err = i.topLevelIndex.InitHandle(r.Comparer, topLevelIndexH, opts.Transforms)
-	}
-	if err != nil {
-		_ = i.Close()
-		return nil, err
-	}
+	// Use lazy loading by default - top-level index will be loaded on first access
+	i.topLevelIndexLoaded = false
 	return i, nil
 }
 
@@ -298,17 +333,34 @@ func (i *twoLevelIterator[I, PI, D, PD]) SeekGE(
 	// block load.
 
 	var dontSeekWithinSingleLevelIter bool
-	if PI(&i.topLevelIndex).IsDataInvalidated() || !PI(&i.topLevelIndex).Valid() || PI(&i.secondLevel.index).IsDataInvalidated() || err != nil ||
-		(i.secondLevel.boundsCmp <= 0 && !flags.TrySeekUsingNext()) || PI(&i.topLevelIndex).SeparatorLT(key) {
+	topLevelIndexIter := i.topLevelIndexIter()
+	if i.secondLevel.err != nil {
+		return nil
+	}
+	if topLevelIndexIter.IsDataInvalidated() || !topLevelIndexIter.Valid() || PI(&i.secondLevel.index).IsDataInvalidated() || err != nil ||
+		(i.secondLevel.boundsCmp <= 0 && !flags.TrySeekUsingNext()) || topLevelIndexIter.SeparatorLT(key) {
+		if i.secondLevel.err != nil {
+			return nil
+		}
 		// Slow-path: need to position the topLevelIndex.
 
 		// The previous exhausted state of singleLevelIterator is no longer
 		// relevant, since we may be moving to a different index block.
 		i.secondLevel.exhaustedBounds = 0
 		flags = flags.DisableTrySeekUsingNext()
-		if !PI(&i.topLevelIndex).SeekGE(key) {
+		topLevelIndexIter = i.topLevelIndexIter()
+		if i.secondLevel.err != nil {
+			return nil
+		}
+		if !topLevelIndexIter.SeekGE(key) {
+			if i.secondLevel.err != nil {
+				return nil
+			}
 			PD(&i.secondLevel.data).Invalidate()
 			PI(&i.secondLevel.index).Invalidate()
+			return nil
+		}
+		if i.secondLevel.err != nil {
 			return nil
 		}
 
@@ -465,17 +517,34 @@ func (i *twoLevelIterator[I, PI, D, PD]) SeekPrefixGE(
 	// block load.
 
 	var dontSeekWithinSingleLevelIter bool
-	if PI(&i.topLevelIndex).IsDataInvalidated() || !PI(&i.topLevelIndex).Valid() || PI(&i.secondLevel.index).IsDataInvalidated() || err != nil ||
-		(i.secondLevel.boundsCmp <= 0 && !flags.TrySeekUsingNext()) || PI(&i.topLevelIndex).SeparatorLT(key) {
+	topLevelIndexIter := i.topLevelIndexIter()
+	if i.secondLevel.err != nil {
+		return nil
+	}
+	if topLevelIndexIter.IsDataInvalidated() || !topLevelIndexIter.Valid() || PI(&i.secondLevel.index).IsDataInvalidated() || err != nil ||
+		(i.secondLevel.boundsCmp <= 0 && !flags.TrySeekUsingNext()) || topLevelIndexIter.SeparatorLT(key) {
+		if i.secondLevel.err != nil {
+			return nil
+		}
 		// Slow-path: need to position the topLevelIndex.
 
 		// The previous exhausted state of singleLevelIterator is no longer
 		// relevant, since we may be moving to a different index block.
 		i.secondLevel.exhaustedBounds = 0
 		flags = flags.DisableTrySeekUsingNext()
-		if !PI(&i.topLevelIndex).SeekGE(key) {
+		topLevelIndexIter = i.topLevelIndexIter()
+		if i.secondLevel.err != nil {
+			return nil
+		}
+		if !topLevelIndexIter.SeekGE(key) {
+			if i.secondLevel.err != nil {
+				return nil
+			}
 			PD(&i.secondLevel.data).Invalidate()
 			PI(&i.secondLevel.index).Invalidate()
+			return nil
+		}
+		if i.secondLevel.err != nil {
 			return nil
 		}
 
@@ -492,8 +561,15 @@ func (i *twoLevelIterator[I, PI, D, PD]) SeekPrefixGE(
 			// separator, the same user key can span multiple index blocks. If
 			// upper is exclusive we pass orEqual=true below, else we require
 			// the separator to be strictly greater than upper.
-			if i.secondLevel.upper != nil && PI(&i.topLevelIndex).SeparatorGT(
+			topLevelIndexIter = i.topLevelIndexIter()
+			if i.secondLevel.err != nil {
+				return nil
+			}
+			if i.secondLevel.upper != nil && topLevelIndexIter.SeparatorGT(
 				i.secondLevel.upper, !i.secondLevel.endKeyInclusive) {
+				if i.secondLevel.err != nil {
+					return nil
+				}
 				i.secondLevel.exhaustedBounds = +1
 			}
 			// Fall through to skipForward.
@@ -593,11 +669,25 @@ func (i *twoLevelIterator[I, PI, D, PD]) virtualLastSeekLE() *base.InternalKV {
 	// Seek optimization only applies until iterator is first positioned with a
 	// SeekGE or SeekLT after SetBounds.
 	i.secondLevel.boundsCmp = 0
-	topLevelOk := PI(&i.topLevelIndex).SeekGE(key)
+	topLevelIndexIter := i.topLevelIndexIter()
+	if i.secondLevel.err != nil {
+		return nil
+	}
+	topLevelOk := topLevelIndexIter.SeekGE(key)
+	if i.secondLevel.err != nil {
+		return nil
+	}
 	// We can have multiple internal keys with the same user key as the seek
 	// key. In that case, we want the last (greatest) internal key.
-	for topLevelOk && bytes.Equal(PI(&i.topLevelIndex).Separator(), key) {
-		topLevelOk = PI(&i.topLevelIndex).Next()
+	for topLevelOk && bytes.Equal(topLevelIndexIter.Separator(), key) {
+		topLevelIndexIter = i.topLevelIndexIter()
+		if i.secondLevel.err != nil {
+			return nil
+		}
+		topLevelOk = topLevelIndexIter.Next()
+		if i.secondLevel.err != nil {
+			return nil
+		}
 	}
 	if !topLevelOk {
 		return i.skipBackward()
@@ -650,10 +740,27 @@ func (i *twoLevelIterator[I, PI, D, PD]) SeekLT(
 	// NB: If a bound-limited block property filter is configured, it's
 	// externally ensured that the filter is disabled (through returning
 	// Intersects=false irrespective of the block props provided) during seeks.
-	if !PI(&i.topLevelIndex).SeekGE(key) {
-		if !PI(&i.topLevelIndex).Last() {
+	topLevelIndexIter := i.topLevelIndexIter()
+	if i.secondLevel.err != nil {
+		return nil
+	}
+	if !topLevelIndexIter.SeekGE(key) {
+		if i.secondLevel.err != nil {
+			return nil
+		}
+		topLevelIndexIter = i.topLevelIndexIter()
+		if i.secondLevel.err != nil {
+			return nil
+		}
+		if !topLevelIndexIter.Last() {
+			if i.secondLevel.err != nil {
+				return nil
+			}
 			PD(&i.secondLevel.data).Invalidate()
 			PI(&i.secondLevel.index).Invalidate()
+			return nil
+		}
+		if i.secondLevel.err != nil {
 			return nil
 		}
 
@@ -671,6 +778,9 @@ func (i *twoLevelIterator[I, PI, D, PD]) SeekLT(
 		}
 		// Else loadBlockIrrelevant, so fall through.
 	} else {
+		if i.secondLevel.err != nil {
+			return nil
+		}
 		result = i.loadSecondLevelIndexBlock(-1)
 		if result == loadBlockFailed {
 			return nil
@@ -691,7 +801,14 @@ func (i *twoLevelIterator[I, PI, D, PD]) SeekLT(
 		// exceeded. Note that the previous entry starts with keys <=
 		// ikey.InternalKey.UserKey since even though this is the current block's
 		// separator, the same user key can span multiple index blocks.
-		if i.secondLevel.lower != nil && PI(&i.topLevelIndex).SeparatorLT(i.secondLevel.lower) {
+		topLevelIndexIter = i.topLevelIndexIter()
+		if i.secondLevel.err != nil {
+			return nil
+		}
+		if i.secondLevel.lower != nil && topLevelIndexIter.SeparatorLT(i.secondLevel.lower) {
+			if i.secondLevel.err != nil {
+				return nil
+			}
 			i.secondLevel.exhaustedBounds = -1
 		}
 	}
@@ -715,7 +832,17 @@ func (i *twoLevelIterator[I, PI, D, PD]) First() *base.InternalKV {
 	// Seek optimization only applies until iterator is first positioned after SetBounds.
 	i.secondLevel.boundsCmp = 0
 
-	if !PI(&i.topLevelIndex).First() {
+	topLevelIndexIter := i.topLevelIndexIter()
+	if i.secondLevel.err != nil {
+		return nil
+	}
+	if !topLevelIndexIter.First() {
+		if i.secondLevel.err != nil {
+			return nil
+		}
+		return nil
+	}
+	if i.secondLevel.err != nil {
 		return nil
 	}
 	result := i.loadSecondLevelIndexBlock(+1)
@@ -735,8 +862,15 @@ func (i *twoLevelIterator[I, PI, D, PD]) First() *base.InternalKV {
 		// block separator, the same user key can span multiple index blocks.
 		// If upper is exclusive we pass orEqual=true below, else we require the
 		// separator to be strictly greater than upper.
-		if i.secondLevel.upper != nil && PI(&i.topLevelIndex).SeparatorGT(
+		topLevelIndexIter = i.topLevelIndexIter()
+		if i.secondLevel.err != nil {
+			return nil
+		}
+		if i.secondLevel.upper != nil && topLevelIndexIter.SeparatorGT(
 			i.secondLevel.upper, !i.secondLevel.endKeyInclusive) {
+			if i.secondLevel.err != nil {
+				return nil
+			}
 			i.secondLevel.exhaustedBounds = +1
 		}
 	}
@@ -764,7 +898,17 @@ func (i *twoLevelIterator[I, PI, D, PD]) Last() *base.InternalKV {
 	// Seek optimization only applies until iterator is first positioned after SetBounds.
 	i.secondLevel.boundsCmp = 0
 
-	if !PI(&i.topLevelIndex).Last() {
+	topLevelIndexIter := i.topLevelIndexIter()
+	if i.secondLevel.err != nil {
+		return nil
+	}
+	if !topLevelIndexIter.Last() {
+		if i.secondLevel.err != nil {
+			return nil
+		}
+		return nil
+	}
+	if i.secondLevel.err != nil {
 		return nil
 	}
 	result := i.loadSecondLevelIndexBlock(-1)
@@ -783,7 +927,14 @@ func (i *twoLevelIterator[I, PI, D, PD]) Last() *base.InternalKV {
 		// entry starts with keys <= ikv.InternalKey.UserKey since even though
 		// this is the current block's separator, the same user key can span
 		// multiple index blocks.
-		if i.secondLevel.lower != nil && PI(&i.topLevelIndex).SeparatorLT(i.secondLevel.lower) {
+		topLevelIndexIter = i.topLevelIndexIter()
+		if i.secondLevel.err != nil {
+			return nil
+		}
+		if i.secondLevel.lower != nil && topLevelIndexIter.SeparatorLT(i.secondLevel.lower) {
+			if i.secondLevel.err != nil {
+				return nil
+			}
 			i.secondLevel.exhaustedBounds = -1
 		}
 	}
@@ -831,9 +982,19 @@ func (i *twoLevelIterator[I, PI, D, PD]) NextPrefix(succKey []byte) *base.Intern
 
 	// Did not find prefix in the existing second-level index block. This is the
 	// slow-path where we seek the iterator.
-	if !PI(&i.topLevelIndex).SeekGE(succKey) {
+	topLevelIndexIter := i.topLevelIndexIter()
+	if i.secondLevel.err != nil {
+		return nil
+	}
+	if !topLevelIndexIter.SeekGE(succKey) {
+		if i.secondLevel.err != nil {
+			return nil
+		}
 		PD(&i.secondLevel.data).Invalidate()
 		PI(&i.secondLevel.index).Invalidate()
+		return nil
+	}
+	if i.secondLevel.err != nil {
 		return nil
 	}
 	result := i.loadSecondLevelIndexBlock(+1)
@@ -848,8 +1009,15 @@ func (i *twoLevelIterator[I, PI, D, PD]) NextPrefix(succKey []byte) *base.Intern
 		// separator, the same user key can span multiple index blocks. If upper
 		// is exclusive we pass orEqual=true below, else we require the
 		// separator to be strictly greater than upper.
-		if i.secondLevel.upper != nil && PI(&i.topLevelIndex).SeparatorGT(
+		topLevelIndexIter = i.topLevelIndexIter()
+		if i.secondLevel.err != nil {
+			return nil
+		}
+		if i.secondLevel.upper != nil && topLevelIndexIter.SeparatorGT(
 			i.secondLevel.upper, !i.secondLevel.endKeyInclusive) {
+			if i.secondLevel.err != nil {
+				return nil
+			}
 			i.secondLevel.exhaustedBounds = +1
 		}
 	} else if kv := i.secondLevel.SeekGE(succKey, base.SeekGEFlagsNone); kv != nil {
@@ -907,13 +1075,30 @@ func (i *twoLevelIterator[I, PI, D, PD]) skipForward() *base.InternalKV {
 		// Note that this is only a problem with virtual tables; we make no
 		// guarantees wrt an iterator lower bound when we iterate forward. But we
 		// must never return keys that are not inside the virtual table.
-		useSeek := i.secondLevel.readEnv.Virtual != nil && (!PI(&i.topLevelIndex).Valid() ||
-			PI(&i.topLevelIndex).SeparatorLT(i.secondLevel.readEnv.Virtual.Lower.UserKey))
+		topLevelIndexIter := i.topLevelIndexIter()
+		if i.secondLevel.err != nil {
+			return nil
+		}
+		useSeek := i.secondLevel.readEnv.Virtual != nil && (!topLevelIndexIter.Valid() ||
+			topLevelIndexIter.SeparatorLT(i.secondLevel.readEnv.Virtual.Lower.UserKey))
+		if i.secondLevel.err != nil {
+			return nil
+		}
 
 		i.secondLevel.exhaustedBounds = 0
-		if !PI(&i.topLevelIndex).Next() {
+		topLevelIndexIter = i.topLevelIndexIter()
+		if i.secondLevel.err != nil {
+			return nil
+		}
+		if !topLevelIndexIter.Next() {
+			if i.secondLevel.err != nil {
+				return nil
+			}
 			PD(&i.secondLevel.data).Invalidate()
 			PI(&i.secondLevel.index).Invalidate()
+			return nil
+		}
+		if i.secondLevel.err != nil {
 			return nil
 		}
 		result := i.loadSecondLevelIndexBlock(+1)
@@ -941,8 +1126,15 @@ func (i *twoLevelIterator[I, PI, D, PD]) skipForward() *base.InternalKV {
 			// multiple index blocks. If upper is exclusive we pass orEqual=true
 			// below, else we require the separator to be strictly greater than
 			// upper.
-			if i.secondLevel.upper != nil && PI(&i.topLevelIndex).SeparatorGT(
+			topLevelIndexIter = i.topLevelIndexIter()
+			if i.secondLevel.err != nil {
+				return nil
+			}
+			if i.secondLevel.upper != nil && topLevelIndexIter.SeparatorGT(
 				i.secondLevel.upper, !i.secondLevel.endKeyInclusive) {
+				if i.secondLevel.err != nil {
+					return nil
+				}
 				i.secondLevel.exhaustedBounds = +1
 				// Next iteration will return.
 			}
@@ -956,9 +1148,19 @@ func (i *twoLevelIterator[I, PI, D, PD]) skipBackward() *base.InternalKV {
 			return nil
 		}
 		i.secondLevel.exhaustedBounds = 0
-		if !PI(&i.topLevelIndex).Prev() {
+		topLevelIndexIter := i.topLevelIndexIter()
+		if i.secondLevel.err != nil {
+			return nil
+		}
+		if !topLevelIndexIter.Prev() {
+			if i.secondLevel.err != nil {
+				return nil
+			}
 			PD(&i.secondLevel.data).Invalidate()
 			PI(&i.secondLevel.index).Invalidate()
+			return nil
+		}
+		if i.secondLevel.err != nil {
 			return nil
 		}
 		result := i.loadSecondLevelIndexBlock(-1)
@@ -980,7 +1182,14 @@ func (i *twoLevelIterator[I, PI, D, PD]) skipBackward() *base.InternalKV {
 			// previous entry starts with keys <= i.topLevelIndex.Separator() since
 			// even though this is the current block's separator, the same user
 			// key can span multiple index blocks.
-			if i.secondLevel.lower != nil && PI(&i.topLevelIndex).SeparatorLT(i.secondLevel.lower) {
+			topLevelIndexIter = i.topLevelIndexIter()
+			if i.secondLevel.err != nil {
+				return nil
+			}
+			if i.secondLevel.lower != nil && topLevelIndexIter.SeparatorLT(i.secondLevel.lower) {
+				if i.secondLevel.err != nil {
+					return nil
+				}
 				i.secondLevel.exhaustedBounds = -1
 				// Next iteration will return.
 			}
@@ -1020,8 +1229,33 @@ func (i *twoLevelIterator[I, PI, D, PD]) Close() error {
 	err = firstError(err, PI(&i.topLevelIndex).Close())
 	i.useFilterBlock = false
 	i.lastBloomFilterMatched = false
+	i.topLevelIndexLoaded = false
 	if pool != nil {
 		pool.Put(i)
 	}
 	return err
+}
+
+func (i *twoLevelIterator[I, PI, D, PD]) ensureTopLevelIndexLoaded() error {
+	if i.topLevelIndexLoaded {
+		return nil
+	}
+
+	topLevelIndexH, err := i.secondLevel.reader.readTopLevelIndexBlock(i.secondLevel.ctx, i.secondLevel.readEnv.Block, i.secondLevel.indexFilterRH)
+	if err == nil {
+		err = PI(&i.topLevelIndex).InitHandle(i.secondLevel.reader.Comparer, topLevelIndexH, i.secondLevel.transforms)
+	}
+	if err != nil {
+		return err
+	}
+
+	i.topLevelIndexLoaded = true
+	return nil
+}
+
+func (i *twoLevelIterator[I, PI, D, PD]) topLevelIndexIter() PI {
+	if err := i.ensureTopLevelIndexLoaded(); err != nil {
+		i.secondLevel.err = err
+	}
+	return PI(&i.topLevelIndex)
 }

--- a/sstable/simple_benchmark_test.go
+++ b/sstable/simple_benchmark_test.go
@@ -1,0 +1,136 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sstable
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/pebble/bloom"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
+	"github.com/cockroachdb/pebble/sstable/block"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+var globalReader *Reader
+var globalIterOpts IterOptions
+
+func init() {
+	// Setup global test data once
+	mem := vfs.NewMem()
+	f, err := mem.Create("bench.sst", vfs.WriteCategoryUnspecified)
+	if err != nil {
+		panic(err)
+	}
+
+	w := NewWriter(objstorageprovider.NewFileWritable(f), WriterOptions{
+		BlockSize:      4096,
+		IndexBlockSize: 4096,
+		FilterPolicy:   bloom.FilterPolicy(10),
+		TableFormat:    TableFormatPebblev3,
+		Comparer:       base.DefaultComparer,
+		MergerName:     base.DefaultMerger.Name,
+	})
+
+	const numKeys = 10000
+	for i := range numKeys {
+		key := fmt.Appendf(nil, "key%08d", i)
+		value := fmt.Sprintf("value%d", i)
+		if err := w.Set(key, []byte(value)); err != nil {
+			panic(err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		panic(err)
+	}
+
+	f2, err := mem.Open("bench.sst")
+	if err != nil {
+		panic(err)
+	}
+
+	globalReader, err = newReader(f2, ReaderOptions{
+		Comparer: base.DefaultComparer,
+		Merger:   base.DefaultMerger,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	var stats base.InternalIteratorStats
+	var bufferPool block.BufferPool
+	bufferPool.Init(5)
+
+	globalIterOpts = IterOptions{
+		Transforms:           NoTransforms,
+		FilterBlockSizeLimit: NeverUseFilterBlock,
+		Env:                  ReadEnv{Block: block.ReadEnv{Stats: &stats, BufferPool: &bufferPool}},
+		ReaderProvider:       MakeTrivialReaderProvider(globalReader),
+	}
+}
+
+// BenchmarkSimpleIteratorConstruction measures pure construction performance
+// How to: go test -bench=BenchmarkSimpleIteratorConstruction -run=^$ ./sstable
+func BenchmarkSimpleIteratorConstruction(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		iter, err := newRowBlockSingleLevelIterator(context.Background(), globalReader, globalIterOpts)
+		if err != nil {
+			b.Fatal(err)
+		}
+		// Don't access index - just construct and close
+		iter.Close()
+	}
+}
+
+// BenchmarkConstructionPlusFirstAccess measures construction + first index access
+// How to: go test -bench=BenchmarkConstructionPlusFirstAccess -run=^$ ./sstable
+func BenchmarkConstructionPlusFirstAccess(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		iter, err := newRowBlockSingleLevelIterator(context.Background(), globalReader, globalIterOpts)
+		if err != nil {
+			b.Fatal(err)
+		}
+		// Trigger index loading
+		_ = iter.First()
+		iter.Close()
+	}
+}
+
+// BenchmarkConstructionPlusSeek measures construction + seek (which loads index)
+// How to: go test -bench=BenchmarkConstructionPlusSeek -run=^$ ./sstable
+func BenchmarkConstructionPlusSeek(b *testing.B) {
+	key := []byte("key00005000")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		iter, err := newRowBlockSingleLevelIterator(context.Background(), globalReader, globalIterOpts)
+		if err != nil {
+			b.Fatal(err)
+		}
+		// Trigger index loading
+		_ = iter.SeekGE(key, base.SeekGEFlagsNone)
+		iter.Close()
+	}
+}
+
+// TestSimpleLazyLoading verifies lazy loading behavior
+func TestSimpleLazyLoading(t *testing.T) {
+	iter, err := newRowBlockSingleLevelIterator(context.Background(), globalReader, globalIterOpts)
+	require.NoError(t, err)
+	defer iter.Close()
+
+	// Index should not be loaded on construction
+	require.False(t, iter.indexLoaded, "Index should not be loaded on construction")
+
+	// Trigger index loading
+	_ = iter.First()
+
+	// Index should now be loaded
+	require.True(t, iter.indexLoaded, "Index should be loaded after first access")
+}

--- a/sstable/two_level_benchmark_test.go
+++ b/sstable/two_level_benchmark_test.go
@@ -1,0 +1,305 @@
+// Copyright 2025 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sstable
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/pebble/bloom"
+	"github.com/cockroachdb/pebble/internal/base"
+	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
+	"github.com/cockroachdb/pebble/sstable/block"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+var globalTwoLevelReader *Reader
+var globalTwoLevelIterOpts IterOptions
+
+func init() {
+	// Setup global test data once - create a two-level index SSTable
+	mem := vfs.NewMem()
+	f, err := mem.Create("two_level_bench.sst", vfs.WriteCategoryUnspecified)
+	if err != nil {
+		panic(err)
+	}
+
+	// Use small index block size to force two-level indexing
+	w := NewWriter(objstorageprovider.NewFileWritable(f), WriterOptions{
+		BlockSize:      4096,
+		IndexBlockSize: 512, // Small index block size forces two-level indexing
+		FilterPolicy:   bloom.FilterPolicy(10),
+		TableFormat:    TableFormatPebblev3,
+		Comparer:       base.DefaultComparer,
+		MergerName:     base.DefaultMerger.Name,
+	})
+
+	// Create enough keys to force multiple index blocks
+	const numKeys = 50000
+	for i := range numKeys {
+		key := fmt.Appendf(nil, "key%08d", i)
+		value := fmt.Sprintf("value%d", i)
+		if err := w.Set(key, []byte(value)); err != nil {
+			panic(err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		panic(err)
+	}
+
+	f2, err := mem.Open("two_level_bench.sst")
+	if err != nil {
+		panic(err)
+	}
+
+	globalTwoLevelReader, err = newReader(f2, ReaderOptions{
+		Comparer: base.DefaultComparer,
+		Merger:   base.DefaultMerger,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Verify we actually created a two-level index
+	if !globalTwoLevelReader.Attributes.Has(AttributeTwoLevelIndex) {
+		panic("Failed to create two-level index SSTable")
+	}
+
+	var stats base.InternalIteratorStats
+	var bufferPool block.BufferPool
+	bufferPool.Init(5)
+
+	globalTwoLevelIterOpts = IterOptions{
+		Transforms:           NoTransforms,
+		FilterBlockSizeLimit: NeverUseFilterBlock,
+		Env:                  ReadEnv{Block: block.ReadEnv{Stats: &stats, BufferPool: &bufferPool}},
+		ReaderProvider:       MakeTrivialReaderProvider(globalTwoLevelReader),
+	}
+}
+
+// simulateEagerTwoLevelLoading creates a two-level iterator and immediately loads the top-level index
+// to simulate what eager loading would have done
+func simulateEagerTwoLevelLoading(r *Reader, opts IterOptions) (*twoLevelIteratorRowBlocks, error) {
+	iter, err := newRowBlockTwoLevelIterator(context.Background(), r, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// Force top-level index loading immediately (simulating eager loading)
+	if err := iter.ensureTopLevelIndexLoaded(); err != nil {
+		iter.Close()
+		return nil, err
+	}
+
+	return iter, nil
+}
+
+// BenchmarkTwoLevelIteratorConstruction measures pure construction performance
+// How to: go test -bench=BenchmarkTwoLevelIteratorConstruction -run=^$ ./sstable
+func BenchmarkTwoLevelIteratorConstruction(b *testing.B) {
+	b.Run("LazyLoading_ConstructOnly", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			iter, err := newRowBlockTwoLevelIterator(context.Background(), globalTwoLevelReader, globalTwoLevelIterOpts)
+			if err != nil {
+				b.Fatal(err)
+			}
+			// Don't access top-level index - just construct and close
+			iter.Close()
+		}
+	})
+
+	b.Run("SimulatedEagerLoading_ConstructOnly", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			iter, err := simulateEagerTwoLevelLoading(globalTwoLevelReader, globalTwoLevelIterOpts)
+			if err != nil {
+				b.Fatal(err)
+			}
+			// Top-level index was loaded during construction
+			iter.Close()
+		}
+	})
+}
+
+// BenchmarkTwoLevelFirstAccessLatency compares the latency of first access operations
+// How to: go test -bench=BenchmarkTwoLevelFirstAccessLatency -run=^$ ./sstable
+func BenchmarkTwoLevelFirstAccessLatency(b *testing.B) {
+	// Benchmark: First() call including top-level index loading time (lazy loading)
+	b.Run("LazyLoading_First", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			iter, err := newRowBlockTwoLevelIterator(context.Background(), globalTwoLevelReader, globalTwoLevelIterOpts)
+			if err != nil {
+				b.Fatal(err)
+			}
+			_ = iter.First() // Top-level index loaded here
+			iter.Close()
+		}
+	})
+
+	// Benchmark: First() call when top-level index is already loaded (simulated eager loading)
+	b.Run("EagerLoading_First", func(b *testing.B) {
+		// Create a single iterator and pre-load its top-level index once
+		iter, err := newRowBlockTwoLevelIterator(context.Background(), globalTwoLevelReader, globalTwoLevelIterOpts)
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer iter.Close()
+
+		_ = iter.First() // Pre-load top-level index
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = iter.First() // Top-level index already loaded - this is what we're measuring
+		}
+	})
+
+	// Benchmark: SeekGE() call including top-level index loading time (lazy loading)
+	b.Run("LazyLoading_SeekGE", func(b *testing.B) {
+		key := []byte("key00025000") // Middle key
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			iter, err := newRowBlockTwoLevelIterator(context.Background(), globalTwoLevelReader, globalTwoLevelIterOpts)
+			if err != nil {
+				b.Fatal(err)
+			}
+			_ = iter.SeekGE(key, base.SeekGEFlagsNone) // Top-level index loaded here
+			iter.Close()
+		}
+	})
+
+	// Benchmark: SeekGE() call when top-level index is already loaded (simulated eager loading)
+	b.Run("EagerLoading_SeekGE", func(b *testing.B) {
+		key := []byte("key00025000") // Middle key
+
+		// Create a single iterator and pre-load its top-level index once
+		iter, err := newRowBlockTwoLevelIterator(context.Background(), globalTwoLevelReader, globalTwoLevelIterOpts)
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer iter.Close()
+
+		_ = iter.First() // Pre-load top-level index
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = iter.SeekGE(key, base.SeekGEFlagsNone) // Top-level index already loaded - this is what we're measuring
+		}
+	})
+}
+
+// BenchmarkTwoLevelIndexLoadingOverhead measures the overhead of lazy loading
+// by comparing subsequent calls on the same iterator
+// How to: go test -bench=BenchmarkTwoLevelIndexLoadingOverhead -run=^$ ./sstable
+func BenchmarkTwoLevelIndexLoadingOverhead(b *testing.B) {
+	b.Run("LazyLoading_FirstCall", func(b *testing.B) {
+		// Create fresh iterators for each call to measure first access (includes index loading)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			iter, err := newRowBlockTwoLevelIterator(context.Background(), globalTwoLevelReader, globalTwoLevelIterOpts)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			// This triggers index loading + navigation
+			b.StartTimer()
+			_ = iter.First()
+			b.StopTimer()
+
+			iter.Close()
+		}
+	})
+
+	b.Run("LazyLoading_SubsequentCall", func(b *testing.B) {
+		// Create one iterator and call First() multiple times to measure subsequent access
+		iter, err := newRowBlockTwoLevelIterator(context.Background(), globalTwoLevelReader, globalTwoLevelIterOpts)
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer iter.Close()
+
+		// Load index once
+		_ = iter.First()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = iter.First() // Index already loaded, just navigation
+		}
+	})
+
+	b.Run("EagerLoading_FirstCall", func(b *testing.B) {
+		// Create fresh eager iterators for each call
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			iter, err := simulateEagerTwoLevelLoading(globalTwoLevelReader, globalTwoLevelIterOpts)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			// Index already loaded, just navigation
+			b.StartTimer()
+			_ = iter.First()
+			b.StopTimer()
+
+			iter.Close()
+		}
+	})
+}
+
+// TestTwoLevelLazyLoadingBehavior verifies that lazy loading works as expected
+// How to: go test -run TestTwoLevelLazyLoadingBehavior -v ./sstable
+func TestTwoLevelLazyLoadingBehavior(t *testing.T) {
+	t.Run("TopLevelIndexNotLoadedOnConstruction", func(t *testing.T) {
+		iter, err := newRowBlockTwoLevelIterator(context.Background(), globalTwoLevelReader, globalTwoLevelIterOpts)
+		require.NoError(t, err)
+		defer iter.Close()
+
+		// Top-level index should not be loaded yet
+		require.False(t, iter.topLevelIndexLoaded, "Top-level index should not be loaded on construction")
+	})
+
+	t.Run("TopLevelIndexLoadedOnFirstAccess", func(t *testing.T) {
+		iter, err := newRowBlockTwoLevelIterator(context.Background(), globalTwoLevelReader, globalTwoLevelIterOpts)
+		require.NoError(t, err)
+		defer iter.Close()
+
+		// Top-level index should not be loaded yet
+		require.False(t, iter.topLevelIndexLoaded, "Top-level index should not be loaded on construction")
+
+		// Trigger top-level index loading
+		_ = iter.First()
+
+		// Top-level index should now be loaded
+		require.True(t, iter.topLevelIndexLoaded, "Top-level index should be loaded after first access")
+	})
+
+	t.Run("TopLevelIndexStaysLoadedAfterPoolReuse", func(t *testing.T) {
+		iter, err := newRowBlockTwoLevelIterator(context.Background(), globalTwoLevelReader, globalTwoLevelIterOpts)
+		require.NoError(t, err)
+
+		// Load the top-level index
+		_ = iter.First()
+		require.True(t, iter.topLevelIndexLoaded, "Top-level index should be loaded after first access")
+
+		// Close and return to pool
+		iter.Close()
+
+		// Create new iterator (may reuse from pool)
+		iter2, err := newRowBlockTwoLevelIterator(context.Background(), globalTwoLevelReader, globalTwoLevelIterOpts)
+		require.NoError(t, err)
+		defer iter2.Close()
+
+		// Top-level index should not be loaded for new iterator (flag reset on pool reuse)
+		require.False(t, iter2.topLevelIndexLoaded, "Top-level index should not be loaded on new iterator from pool")
+	})
+
+	t.Run("VerifyTwoLevelIndex", func(t *testing.T) {
+		// Verify that our test SSTable actually has a two-level index
+		require.True(t, globalTwoLevelReader.Attributes.Has(AttributeTwoLevelIndex), "Test SSTable should have two-level index")
+	})
+}

--- a/testdata/checkpoint
+++ b/testdata/checkpoint
@@ -261,16 +261,16 @@ open: db/000007.sst (options: *vfs.randomReadsOption)
 read-at(700, 61): db/000007.sst
 read-at(649, 51): db/000007.sst
 read-at(132, 517): db/000007.sst
-read-at(91, 41): db/000005.sst
 open: db/000005.sst (options: *vfs.sequentialReadsOption)
+read-at(91, 41): db/000005.sst
 read-at(0, 91): db/000005.sst
-read-at(91, 41): db/000007.sst
 open: db/000007.sst (options: *vfs.sequentialReadsOption)
+read-at(91, 41): db/000007.sst
 read-at(0, 91): db/000007.sst
 create: db/000010.sst
 close: db/000005.sst
-read-at(95, 41): db/000009.sst
 open: db/000009.sst (options: *vfs.sequentialReadsOption)
+read-at(95, 41): db/000009.sst
 read-at(0, 95): db/000009.sst
 close: db/000007.sst
 close: db/000009.sst

--- a/testdata/cleaner
+++ b/testdata/cleaner
@@ -82,13 +82,13 @@ open: db/000007.sst (options: *vfs.randomReadsOption)
 read-at(501, 61): db/000007.sst
 read-at(472, 37): db/000007.sst
 read-at(53, 419): db/000007.sst
-read-at(52, 27): db/000005.sst
 open: db/000005.sst (options: *vfs.sequentialReadsOption)
+read-at(52, 27): db/000005.sst
 read-at(0, 52): db/000005.sst
 create: db/000008.sst
 close: db/000005.sst
-read-at(26, 27): db/000007.sst
 open: db/000007.sst (options: *vfs.sequentialReadsOption)
+read-at(26, 27): db/000007.sst
 read-at(0, 26): db/000007.sst
 close: db/000007.sst
 sync-data: db/000008.sst

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -145,11 +145,11 @@ open: db/000008.sst (options: *vfs.randomReadsOption)
 read-at(686, 61): db/000008.sst
 read-at(636, 50): db/000008.sst
 read-at(119, 517): db/000008.sst
-read-at(78, 41): db/000005.sst
 open: db/000005.sst (options: *vfs.sequentialReadsOption)
+read-at(78, 41): db/000005.sst
 read-at(0, 78): db/000005.sst
-read-at(78, 41): db/000008.sst
 open: db/000008.sst (options: *vfs.sequentialReadsOption)
+read-at(78, 41): db/000008.sst
 read-at(0, 78): db/000008.sst
 close: db/000008.sst
 close: db/000005.sst

--- a/testdata/flushable_ingest
+++ b/testdata/flushable_ingest
@@ -651,17 +651,17 @@ allowFlush
 get with-fs-logging
 small-00001
 ----
-read-at(158, 41): 000004.sst
 read-at(199, 74): 000004.sst
+read-at(158, 41): 000004.sst
 read-at(0, 158): 000004.sst
 small-00001:val-00001
 
-# When the key doesn't pass the bloom filter, we should see only two block
-# reads.
+# When the key doesn't pass the bloom filter, we should see only one block
+# read due to lazy loading optimization - bloom filter is checked first,
+# and if it rejects the key, we can avoid loading the index block entirely.
 get with-fs-logging
 small-00001-does-not-exist
 ----
-read-at(158, 41): 000004.sst
 read-at(199, 74): 000004.sst
 small-00001-does-not-exist: pebble: not found
 


### PR DESCRIPTION
This commit implements the index block lazy loading in two-level iterator as default behavior. The top level index block loading is deferred until first access.

Here is a comparison between eager loading and lazy loading.

| Operation | Eager Loading | Lazy Loading | Performance |
| --------- | ------------- | ------------ | ---------------- |
| Constructor | ~280ns/op | ~70ns/op | ~4x faster |
| First Access | ~1820ns/op | ~2140ns/op | ~17.5% slower |

implements #3248