### PR TITLE
arenaskl: add use-after-free detection for memtable arenas

### DIFF
--- a/db.go
+++ b/db.go
@@ -2358,6 +2358,18 @@ func (d *DB) newMemTable(
 
 	entry := d.newFlushableEntry(mem, logNum, logSeqNum)
 	entry.releaseMemAccounting = func() {
+		// Invalidate the old skiplist arenas before recycling or freeing.
+		// This nils each Arena.buf so any stale iterator that outlived its
+		// readState will panic immediately on the nil slice instead of
+		// silently reading from the recycled/freed buffer. The buffer
+		// contents are NOT modified, preserving it for potential recycling.
+		//
+		// TODO(cockroach#166984): diagnostic scaffolding for suspected
+		// use-after-free. Remove once root cause is identified and fixed.
+		mem.skl.Arena().Invalidate()
+		mem.rangeDelSkl.Arena().Invalidate()
+		mem.rangeKeySkl.Arena().Invalidate()
+
 		// If the user leaks iterators, we may be releasing the memtable after
 		// the DB is already closed. In this case, we want to just release the
 		// memory because DB.Close won't come along to free it for us.

--- a/internal/arenaskl/arena.go
+++ b/internal/arenaskl/arena.go
@@ -18,7 +18,10 @@
 package arenaskl
 
 import (
+	"fmt"
 	"math"
+	"runtime"
+	"sync"
 	"sync/atomic"
 	"unsafe"
 
@@ -41,6 +44,40 @@ var (
 )
 
 const MaxArenaSize = min(math.MaxUint32, math.MaxInt)
+
+// freedArenaStacks stores the stack traces of freed/recycled arenas.
+// Only populated in invariant builds. When a use-after-free is detected,
+// the stored stack identifies who freed/recycled the arena.
+//
+// Diagnostic scaffolding for cockroach#166984: suspected use-after-free
+// in the memtable skiplist arena. This infrastructure converts a silent
+// memory corruption (stale iterator reading freed arena) into a
+// deterministic panic with both the read-site and free-site stack traces.
+// TODO(cockroach#166984): remove once root cause is identified and fixed.
+var freedArenaStacks sync.Map // uintptr(*Arena) → []uintptr
+
+func recordFreedStack(a *Arena) {
+	var callers [8]uintptr
+	n := runtime.Callers(2, callers[:])
+	freedArenaStacks.Store(uintptr(unsafe.Pointer(a)), callers[:n])
+}
+
+func lookupFreedStack(a *Arena) string {
+	v, ok := freedArenaStacks.Load(uintptr(unsafe.Pointer(a)))
+	if !ok {
+		return "(no stack captured)"
+	}
+	frames := runtime.CallersFrames(v.([]uintptr))
+	var s string
+	for {
+		frame, more := frames.Next()
+		s += fmt.Sprintf("  %s\n    %s:%d\n", frame.Function, frame.File, frame.Line)
+		if !more {
+			break
+		}
+	}
+	return s
+}
 
 // NewArena allocates a new arena using the specified buffer as the backing
 // store.
@@ -109,12 +146,20 @@ func (a *Arena) getBytes(offset uint32, size uint32) []byte {
 	if offset == 0 {
 		return nil
 	}
+	if invariants.Enabled && a.buf == nil {
+		panic(errors.AssertionFailedf(
+			"use-after-free: arena access after free/recycle.\nFreed at:\n%s", lookupFreedStack(a)))
+	}
 	return a.buf[offset : offset+size : offset+size]
 }
 
 func (a *Arena) getPointer(offset uint32) unsafe.Pointer {
 	if offset == 0 {
 		return nil
+	}
+	if invariants.Enabled && a.buf == nil {
+		panic(errors.AssertionFailedf(
+			"use-after-free: arena access after free/recycle.\nFreed at:\n%s", lookupFreedStack(a)))
 	}
 	return unsafe.Pointer(&a.buf[offset])
 }
@@ -124,4 +169,40 @@ func (a *Arena) getPointerOffset(ptr unsafe.Pointer) uint32 {
 		return 0
 	}
 	return uint32(uintptr(ptr) - uintptr(unsafe.Pointer(&a.buf[0])))
+}
+
+// Poison invalidates the arena so that any subsequent access panics on
+// the nil buf slice. In invariant builds, the buffer is first filled
+// with 0xCC and the caller stack is recorded for diagnostic purposes.
+//
+// Called from memTable.free() when the arena buffer is returned to the
+// C allocator. After this call, any stale iterator accessing this arena
+// will panic immediately instead of silently reading freed memory.
+//
+// TODO(cockroach#166984): diagnostic scaffolding for suspected
+// use-after-free. Remove once root cause is identified and fixed.
+func (a *Arena) Poison() {
+	if invariants.Enabled {
+		recordFreedStack(a)
+	}
+	invariants.Mangle(a.buf)
+	a.buf = nil
+}
+
+// Invalidate disconnects this Arena from its backing buffer by nil-ing
+// the buf slice, without modifying the buffer contents. Use instead of
+// Poison when the buffer will be reused (e.g., memtable recycling). In
+// invariant builds, the caller stack is recorded for diagnostic purposes.
+//
+// Called from releaseMemAccounting before stashing the memtable for
+// recycling. The old Arena object becomes disconnected from the buffer,
+// which will be reused by a new Arena in the next memTable.init() call.
+//
+// TODO(cockroach#166984): diagnostic scaffolding for suspected
+// use-after-free. Remove once root cause is identified and fixed.
+func (a *Arena) Invalidate() {
+	if invariants.Enabled {
+		recordFreedStack(a)
+	}
+	a.buf = nil
 }

--- a/mem_table.go
+++ b/mem_table.go
@@ -92,6 +92,17 @@ type memTable struct {
 func (m *memTable) free() {
 	if m != nil {
 		m.releaseAccountingReservation()
+		// Poison skiplist arenas before freeing the underlying buffer.
+		// This nils each Arena.buf so any stale iterator accessing these
+		// skiplists will panic immediately instead of silently reading
+		// freed memory. In invariant builds, also captures the free-site
+		// stack for diagnostics.
+		//
+		// TODO(cockroach#166984): diagnostic scaffolding for suspected
+		// use-after-free. Remove once root cause is identified and fixed.
+		m.skl.Arena().Poison()
+		m.rangeDelSkl.Arena().Poison()
+		m.rangeKeySkl.Arena().Poison()
 		manual.Free(manual.MemTable, m.arenaBuf)
 		m.arenaBuf = manual.Buf{}
 	}


### PR DESCRIPTION
## Summary

Add diagnostic instrumentation to detect use-after-free of memtable
skiplist arenas. This addresses cockroachdb/cockroach#166984, where
Pebble panics in `findSpliceForLevel` with a corrupted arena offset
(`0xAA66FEF3` vs 64MB capacity), suspected to be caused by an iterator
accessing a freed memtable arena.

The changes nil `Arena.buf` when a memtable is freed or recycled. In
production builds, this converts silent memory corruption into a
deterministic crash (nil slice panic). In invariant builds, it
additionally captures the free-site stack trace and reports it in the
panic message, giving both the "who freed it" and "who accessed it"
stacks needed to identify the race.

## Design

Two invalidation paths, matching the two memtable disposal paths:

- `Arena.Poison()`: called from `memTable.free()` (the `C.free` path).
  Mangles buffer with 0xCC (invariant builds only), then nils `Arena.buf`.

- `Arena.Invalidate()`: called from `releaseMemAccounting` (the recycle
  path). Nils `Arena.buf` without touching the buffer contents, since the
  buffer will be reused by the next memtable.

In invariant builds, both methods capture `runtime.Callers()` into a
package-level `sync.Map`. The `getBytes()` and `getPointer()` accessors
check for nil `Arena.buf` and panic with the free-site stack included.

## Production impact

None. The Arena struct is unchanged. All diagnostic logic
(`runtime.Callers`, `sync.Map`, `getBytes`/`getPointer` nil checks) is
gated behind `invariants.Enabled`, a compile-time constant that is
`false` in production builds and dead-code eliminated by the compiler.
The only production-visible change is `a.buf = nil` in Poison/Invalidate:
one pointer write per memtable free/recycle, executed off the read/write
hot path.

## What you get when it panics

| Build | Panic message | Info |
|-------|--------------|------|
| Production | `index out of range` (nil slice) | Confirms UAF. Read-site stack only. |
| Invariant | `use-after-free: arena access after free/recycle. Freed at: <stack>` | Both read-site and free-site stacks. |

## Removal plan

All changes are marked `TODO(cockroach#166984)`. Once the root cause is
identified and fixed, remove: `Poison()`, `Invalidate()`,
`freedArenaStacks`, `getBytes`/`getPointer` nil checks, and the call
sites in `memTable.free()` and `releaseMemAccounting`. The `a.buf = nil`
in `memTable.free()` may optionally be kept as permanent defense-in-depth.

## Test plan

- [x] Existing `arenaskl` tests pass with invariants and race detector
- [x] Core Pebble tests (Get, Flush, MemTable) pass with and without invariants
- [x] Stress test (168M ops on 96-CPU VM) confirms no false positives